### PR TITLE
fix file and form schema route function

### DIFF
--- a/ellar/common/params/args/request_model.py
+++ b/ellar/common/params/args/request_model.py
@@ -106,9 +106,6 @@ class RequestEndpointArgsModel(EndpointArgsModel):
             and len(body_resolvers) == 1
             and not (
                 body_resolvers[0].model_field.field_info.embed  # type: ignore[attr-defined]
-                and isinstance(
-                    body_resolvers[0].model_field.field_info, params.BodyFieldInfo
-                )
             )
         ):
             check_file_field(body_resolvers[0].model_field)

--- a/ellar/common/params/resolvers/base.py
+++ b/ellar/common/params/resolvers/base.py
@@ -14,6 +14,8 @@ class RouteParameterModelField(ModelField):
 
 
 class IRouteParameterResolver(ABC, metaclass=ABCMeta):
+    model_field: t.Union[RouteParameterModelField, ModelField]
+
     @abstractmethod
     @t.no_type_check
     async def resolve(self, *args: t.Any, **kwargs: t.Any) -> t.Tuple:

--- a/tests/test_routing/document_results.py
+++ b/tests/test_routing/document_results.py
@@ -41,6 +41,48 @@ FORM_OPENAPI_DOC = {
                 },
             }
         },
+        "/form-with-schema-spreading": {
+            "post": {
+                "tags": ["default"],
+                "operationId": "form_params_schema_spreading_form_with_schema_spreading_post",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "title": "Body",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/body_form_params_schema_spreading_form_with_schema_spreading_post"
+                                    }
+                                ],
+                                "include_in_schema": True,
+                            }
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"title": "Response Model", "type": "object"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
         "/mixed": {
             "post": {
                 "tags": ["default"],
@@ -183,6 +225,12 @@ FORM_OPENAPI_DOC = {
                     }
                 },
             },
+            "Range": {
+                "title": "Range",
+                "enum": [20, 50, 200],
+                "type": "integer",
+                "description": "An enumeration.",
+            },
             "ValidationError": {
                 "title": "ValidationError",
                 "required": ["loc", "msg", "type"],
@@ -195,6 +243,37 @@ FORM_OPENAPI_DOC = {
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
+                },
+            },
+            "body_form_params_schema_spreading_form_with_schema_spreading_post": {
+                # form inputs are combined into one just like json body fields
+                "title": "body_form_params_schema_spreading_form_with_schema_spreading_post",
+                "required": ["momentOfTruth"],
+                "type": "object",
+                "properties": {
+                    "momentOfTruth": {
+                        "title": "Momentoftruth",
+                        "type": "string",
+                        "format": "binary",
+                        "include_in_schema": True,
+                    },
+                    "to": {
+                        "title": "To",
+                        "type": "string",
+                        "format": "date-time",
+                        "include_in_schema": True,
+                    },
+                    "from": {
+                        "title": "From",
+                        "type": "string",
+                        "format": "date-time",
+                        "include_in_schema": True,
+                    },
+                    "range": {
+                        "allOf": [{"$ref": "#/components/schemas/Range"}],
+                        "default": 20,
+                        "include_in_schema": True,
+                    },
                 },
             },
             "body_form_upload_multiple_case_2_mixed_optional_post": {

--- a/tests/test_routing/document_results.py
+++ b/tests/test_routing/document_results.py
@@ -10,9 +10,12 @@ FORM_OPENAPI_DOC = {
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "title": "Test",
-                                "type": "string",
-                                "format": "binary",
+                                "title": "Body",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/body_form_upload_single_case_1__post"
+                                    }
+                                ],
                                 "include_in_schema": True,
                             }
                         }
@@ -174,14 +177,12 @@ FORM_OPENAPI_DOC = {
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "title": "Test1",
-                                "type": "array",
-                                "items": {
-                                    "anyOf": [
-                                        {"type": "string", "format": "binary"},
-                                        {"type": "string"},
-                                    ]
-                                },
+                                "title": "Body",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/body_form_upload_multiple_case_1_multiple_post"
+                                    }
+                                ],
                                 "include_in_schema": True,
                             }
                         }
@@ -276,6 +277,24 @@ FORM_OPENAPI_DOC = {
                     },
                 },
             },
+            "body_form_upload_multiple_case_1_multiple_post": {
+                "title": "body_form_upload_multiple_case_1_multiple_post",
+                "required": ["test1"],
+                "type": "object",
+                "properties": {
+                    "test1": {
+                        "title": "Test1",
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {"type": "string", "format": "binary"},
+                                {"type": "string"},
+                            ]
+                        },
+                        "include_in_schema": True,
+                    }
+                },
+            },
             "body_form_upload_multiple_case_2_mixed_optional_post": {
                 "title": "body_form_upload_multiple_case_2_mixed_optional_post",
                 "type": "object",
@@ -297,6 +316,19 @@ FORM_OPENAPI_DOC = {
                         "type": "string",
                         "include_in_schema": True,
                     },
+                },
+            },
+            "body_form_upload_single_case_1__post": {
+                "title": "body_form_upload_single_case_1__post",
+                "required": ["test"],
+                "type": "object",
+                "properties": {
+                    "test": {
+                        "title": "Test",
+                        "type": "string",
+                        "format": "binary",
+                        "include_in_schema": True,
+                    }
                 },
             },
             "body_form_upload_single_case_2_mixed_post": {

--- a/tests/test_routing/test_form_schema.py
+++ b/tests/test_routing/test_form_schema.py
@@ -93,15 +93,44 @@ def test_schema():
     params = document["paths"]["/form-schema"]["post"]["requestBody"]
     assert params == {
         "content": {
-            "application/x-www-form-urlencoded": {
+            "application/form-data": {
                 "schema": {
-                    "allOf": [{"$ref": "#/components/schemas/Filter"}],
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/body_form_params_schema_form_schema_post"
+                        }
+                    ],
                     "include_in_schema": True,
-                    "title": "Will Not Work For Schema With Many Field",
+                    "title": "Body",
                 }
             }
+        }
+    }
+    schema = document["components"]["schemas"][
+        "body_form_params_schema_form_schema_post"
+    ]
+    assert schema == {
+        "title": "body_form_params_schema_form_schema_post",
+        "type": "object",
+        "properties": {
+            "to": {
+                "title": "To",
+                "type": "string",
+                "format": "date-time",
+                "include_in_schema": True,
+            },
+            "from": {
+                "title": "From",
+                "type": "string",
+                "format": "date-time",
+                "include_in_schema": True,
+            },
+            "range": {
+                "allOf": [{"$ref": "#/components/schemas/Range"}],
+                "default": 20,
+                "include_in_schema": True,
+            },
         },
-        "required": True,
     }
 
 


### PR DESCRIPTION
## Whats changed
- File and Form schema openapi docs
```python
class Range(IntEnum):
    TWENTY = 20
    FIFTY = 50
    TWO_HUNDRED = 200


class Filter(Serializer):
    to_datetime: datetime = Field(alias="to")
    from_datetime: datetime = Field(alias="from")
    range: Range = Range.TWENTY


mr = ModuleRouter("")


@mr.post("/form-schema")
def form_params_schema(
    file: File[UploadFile],
    filters: Filter = Form(..., alias="will_not_work_for_schema_with_many_field"),
):
    return dict(filters.dict(), file_name=file.filename)
```

<img width="1728" alt="Screenshot 2023-11-12 at 12 33 34 PM" src="https://github.com/python-ellar/ellar/assets/16435810/d80074ac-bbe3-4414-8824-2a1903d4e080">
