### PR TITLE
Feat(LazyModuleImport): New feature

### DIFF
--- a/ellar/app/factory.py
+++ b/ellar/app/factory.py
@@ -6,8 +6,7 @@ from uuid import uuid4
 from ellar.common import EllarTyper
 from ellar.common.constants import MODULE_METADATA, MODULE_WATERMARK
 from ellar.common.models import GuardCanActivate
-from ellar.core.conf import Config
-from ellar.core.modules import DynamicModule, ModuleBase, ModuleSetup
+from ellar.core import Config, DynamicModule, LazyModuleImport, ModuleBase, ModuleSetup
 from ellar.di import EllarInjector, ProviderConfig
 from ellar.reflect import reflect
 from starlette.routing import Host, Mount
@@ -48,6 +47,9 @@ class AppFactory:
         )
         module_dependency = OrderedDict()
         for module in modules:
+            if isinstance(module, LazyModuleImport):
+                module = module.get_module(module_config.module.__name__)
+
             if isinstance(module, DynamicModule):
                 module.apply_configuration()
                 module_config = ModuleSetup(module.module)

--- a/ellar/app/lifespan.py
+++ b/ellar/app/lifespan.py
@@ -1,9 +1,9 @@
 import typing as t
+from contextlib import asynccontextmanager
 
 from anyio import create_task_group
 from ellar.common import IApplicationShutdown, IApplicationStartup
 from ellar.common.logger import logger
-from ellar.reflect import asynccontextmanager
 
 if t.TYPE_CHECKING:
     from ellar.app import App

--- a/ellar/auth/policy/base.py
+++ b/ellar/auth/policy/base.py
@@ -40,7 +40,7 @@ class _PolicyOperandMixin:
 
     @t.no_type_check
     def __invert__(
-        cls: t.Union["BasePolicyHandler", t.Type["BasePolicyHandler"]]
+        cls: t.Union["BasePolicyHandler", t.Type["BasePolicyHandler"]],
     ) -> "BasePolicyHandler":
         return _NOTPolicy(cls)
 

--- a/ellar/common/datastructures.py
+++ b/ellar/common/datastructures.py
@@ -25,7 +25,7 @@ from starlette.datastructures import (
 from starlette.datastructures import (
     URLPath,
 )
-from typing_extensions import Annotated, Doc  # type: ignore[attr-defined]
+from typing_extensions import Annotated, Doc
 
 __all__ = [
     "URL",

--- a/ellar/common/decorators/exception.py
+++ b/ellar/common/decorators/exception.py
@@ -19,7 +19,7 @@ def _add_exception_handler(
 
 
 def exception_handler(
-    exc_class_or_status_code: t.Union[int, t.Type[Exception]]
+    exc_class_or_status_code: t.Union[int, t.Type[Exception]],
 ) -> t.Callable:
     """
     ========= MODULE DECORATOR ==============

--- a/ellar/common/decorators/guards.py
+++ b/ellar/common/decorators/guards.py
@@ -9,7 +9,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 def UseGuards(
-    *_guards: t.Union[t.Type["GuardCanActivate"], "GuardCanActivate"]
+    *_guards: t.Union[t.Type["GuardCanActivate"], "GuardCanActivate"],
 ) -> t.Callable:
     """
     =========CONTROLLER AND ROUTE FUNCTION DECORATOR ==============

--- a/ellar/common/decorators/interceptor.py
+++ b/ellar/common/decorators/interceptor.py
@@ -9,7 +9,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 def UseInterceptors(
-    *args: t.Union[t.Type["EllarInterceptor"], "EllarInterceptor"]
+    *args: t.Union[t.Type["EllarInterceptor"], "EllarInterceptor"],
 ) -> t.Callable:
     """
     =========CONTROLLER AND FUNCTION DECORATOR ==============

--- a/ellar/common/params/decorators/inject.py
+++ b/ellar/common/params/decorators/inject.py
@@ -47,7 +47,7 @@ def add_default_resolver(
 
 
 def get_default_resolver(
-    type_identifier: t.Union[t.Type, str]
+    type_identifier: t.Union[t.Type, str],
 ) -> t.Optional[t.Type[SystemParameterResolver]]:
     return _DEFAULT_RESOLVERS.get(type_identifier)
 

--- a/ellar/common/params/resolvers/parameter.py
+++ b/ellar/common/params/resolvers/parameter.py
@@ -273,7 +273,7 @@ class FileParameterResolver(FormParameterResolver):
             results: t.List[t.Union[bytes, str]] = []
 
             async def process_fn(
-                fn: t.Callable[[], t.Coroutine[t.Any, t.Any, t.Any]]
+                fn: t.Callable[[], t.Coroutine[t.Any, t.Any, t.Any]],
             ) -> None:
                 result = await fn()
                 results.append(result)

--- a/ellar/core/__init__.py
+++ b/ellar/core/__init__.py
@@ -4,7 +4,7 @@ from .conf import Config, ConfigDefaultTypesMixin
 from .connection import HTTPConnection, Request, WebSocket
 from .execution_context import ExecutionContext, HostContext
 from .guards import GuardConsumer
-from .modules import DynamicModule, ModuleBase, ModuleSetup
+from .modules import DynamicModule, LazyModuleImport, ModuleBase, ModuleSetup
 from .services import Reflector, reflector
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "Reflector",
     "reflector",
     "GuardConsumer",
+    "LazyModuleImport",
 ]
 
 

--- a/ellar/core/modules/__init__.py
+++ b/ellar/core/modules/__init__.py
@@ -1,5 +1,5 @@
 from .base import ModuleBase, ModuleBaseMeta
-from .config import DynamicModule, ModuleSetup
+from .config import DynamicModule, LazyModuleImport, ModuleSetup
 from .ref import ModulePlainRef, ModuleRefBase, ModuleTemplateRef
 
 __all__ = [
@@ -10,4 +10,5 @@ __all__ = [
     "ModuleSetup",
     "DynamicModule",
     "ModuleBaseMeta",
+    "LazyModuleImport",
 ]

--- a/ellar/core/routing/helper.py
+++ b/ellar/core/routing/helper.py
@@ -37,7 +37,7 @@ def build_route_handler(item: t.Callable) -> t.Optional[RouteOperationBase]:
 
 @t.no_type_check
 def build_route_parameters(
-    items: t.List[t.Union[RouteParameters, WsRouteParameters]]
+    items: t.List[t.Union[RouteParameters, WsRouteParameters]],
 ) -> t.List[RouteOperationBase]:
     results = []
     for item in items:

--- a/ellar/di/injector/ellar_injector.py
+++ b/ellar/di/injector/ellar_injector.py
@@ -1,8 +1,8 @@
 import typing as t
 from collections import OrderedDict, defaultdict
+from contextlib import asynccontextmanager
 
 from ellar.di.logger import log
-from ellar.reflect import asynccontextmanager
 from injector import Injector, Scope, ScopeDecorator
 
 from ..asgi_args import RequestScopeContext

--- a/ellar/di/service_config.py
+++ b/ellar/di/service_config.py
@@ -83,7 +83,7 @@ class _Injectable:
 
 
 def injectable(
-    scope: t.Optional[t.Union[t.Type[Scope], ScopeDecorator, t.Type]] = SingletonScope
+    scope: t.Optional[t.Union[t.Type[Scope], ScopeDecorator, t.Type]] = SingletonScope,
 ) -> t.Union[ConstructorOrClassT, t.Callable]:
     """Decorates a callable or Type with inject and Defines Type or callable scope injection scope
 

--- a/ellar/pydantic/encoder.py
+++ b/ellar/pydantic/encoder.py
@@ -51,7 +51,7 @@ ENCODERS_BY_TYPE: t.Dict[t.Type[t.Any], t.Callable[[t.Any], t.Any]] = {
 
 
 def generate_encoders_by_class_tuples(
-    type_encoder_map: t.Dict[t.Any, t.Callable[[t.Any], t.Any]]
+    type_encoder_map: t.Dict[t.Any, t.Callable[[t.Any], t.Any]],
 ) -> t.Dict[t.Callable[[t.Any], t.Any], t.Tuple[t.Any, ...]]:
     encoders_by_class_tuples: t.Dict[
         t.Callable[[t.Any], t.Any], t.Tuple[t.Any, ...]

--- a/ellar/pydantic/utils.py
+++ b/ellar/pydantic/utils.py
@@ -187,7 +187,7 @@ def field_annotation_is_scalar(annotation: t.Any) -> bool:
 
 
 def field_annotation_is_scalar_sequence(
-    annotation: t.Union[t.Type[t.Any], None]
+    annotation: t.Union[t.Type[t.Any], None],
 ) -> bool:
     origin = get_origin(annotation)
     if origin is t.Union or origin is UnionType:

--- a/ellar/reflect/__init__.py
+++ b/ellar/reflect/__init__.py
@@ -1,5 +1,4 @@
 from ._reflect import reflect
 from .constants import REFLECT_TYPE
-from .contextmanager_fix import asynccontextmanager
 
-__all__ = ["reflect", "asynccontextmanager", "REFLECT_TYPE"]
+__all__ = ["reflect", "REFLECT_TYPE"]

--- a/ellar/reflect/_reflect.py
+++ b/ellar/reflect/_reflect.py
@@ -1,17 +1,16 @@
 import logging
 import typing as t
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from inspect import ismethod
 from weakref import WeakKeyDictionary
 
 from .constants import REFLECT_TYPE
-from .contextmanager_fix import asynccontextmanager
 
 logger = logging.getLogger("ellar")
 
 
 def _get_actual_target(
-    target: t.Union[t.Type, t.Callable]
+    target: t.Union[t.Type, t.Callable],
 ) -> t.Union[t.Type, t.Callable]:
     try:
         reflect_type = target.__dict__[REFLECT_TYPE]

--- a/ellar/reflect/contextmanager_fix.py
+++ b/ellar/reflect/contextmanager_fix.py
@@ -1,6 +1,0 @@
-import sys
-
-if sys.version_info >= (3, 7):  # pragma: no cover
-    from contextlib import asynccontextmanager as asynccontextmanager
-else:  # pragma: no cover
-    from contextlib2 import asynccontextmanager as asynccontextmanager  # noqa

--- a/ellar/socket_io/testing/module.py
+++ b/ellar/socket_io/testing/module.py
@@ -1,7 +1,7 @@
 import typing as t
+from contextlib import asynccontextmanager
 
 import socketio
-from ellar.reflect import asynccontextmanager
 from ellar.testing.module import Test, TestingModule
 from ellar.testing.uvicorn_server import EllarUvicornServer
 

--- a/tests/test_application/test_application_functions.py
+++ b/tests/test_application/test_application_functions.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+from contextlib import asynccontextmanager
 
 from ellar.app import App, AppFactory
 from ellar.app.services import EllarAppService
@@ -28,7 +29,6 @@ from ellar.core.versioning import (
 )
 from ellar.di import EllarInjector
 from ellar.openapi import OpenAPIDocumentModule
-from ellar.reflect import asynccontextmanager
 from ellar.testing import Test, TestClient
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 

--- a/tests/test_middleware/test_functional_middleware.py
+++ b/tests/test_middleware/test_functional_middleware.py
@@ -1,7 +1,8 @@
+from contextlib import asynccontextmanager
+
 from ellar.common import IHostContext, Inject, Module, ModuleRouter, middleware
 from ellar.core import ModuleBase
 from ellar.core.middleware import FunctionBasedMiddleware
-from ellar.reflect import asynccontextmanager
 from ellar.testing import Test
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse

--- a/tests/test_modules/test_module_startup_shutdown.py
+++ b/tests/test_modules/test_module_startup_shutdown.py
@@ -1,5 +1,6 @@
+from contextlib import asynccontextmanager
+
 from ellar.common import IApplicationShutdown, IApplicationStartup, Module, ModuleRouter
-from ellar.reflect import asynccontextmanager
 from ellar.testing import Test
 
 router = ModuleRouter("")


### PR DESCRIPTION
## Whats new
- Added support to lazily load a ellar module through string import
```python
# In module.py
import ellar.common as ecm

@ecm.Module()
class ModuleSample:
    pass

# in ApplicationModule
import ellar.core as eco
import ellar.common as ecm


@ecm.Module(modules=[eco.LazyModuleImport('project.module:ModuleSample')])
class ApplicationModule(eco.ModuleBase):
   pass
```