### PR TITLE
fix: TestingModule metadata sharing during tests

### DIFF
--- a/ellar/__init__.py
+++ b/ellar/__init__.py
@@ -1,3 +1,3 @@
 """Ellar - Python ASGI web framework for building fast, efficient, and scalable RESTful APIs and server-side applications."""
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"

--- a/tests/test_modules/test_module_config.py
+++ b/tests/test_modules/test_module_config.py
@@ -200,7 +200,7 @@ def test_dynamic_module_haves_routes():
     mount0 = ModuleRouterBuilder.build(routers[0])
     assert len(mount0.routes) == 39
     tm = Test.create_test_module(
-        modules=(DynamicInstantiatedModule.setup(a=233, b=344),)
+        modules=(DynamicInstantiatedModule.setup(a=233, b=344),), modify_modules=False
     )
     tm.create_application()
     routers = reflect.get_metadata(MODULE_METADATA.ROUTERS, DynamicInstantiatedModule)


### PR DESCRIPTION
## What's changed:
- Fixed Testing Module reusing metadata from previous tests especially for Dynamic and ModuleStep type of modules