### PR TITLE
fix: Application Context Round Usage

### DIFF
--- a/ellar/app/__init__.py
+++ b/ellar/app/__init__.py
@@ -1,4 +1,5 @@
-from .context import config, current_injector
+from ellar.core.context import config, current_injector
+
 from .factory import AppFactory
 from .main import App
 

--- a/ellar/app/factory.py
+++ b/ellar/app/factory.py
@@ -7,6 +7,7 @@ from ellar.common import IApplicationReady, Module
 from ellar.common.constants import MODULE_METADATA, MODULE_WATERMARK
 from ellar.common.models import GuardCanActivate
 from ellar.core import Config, DynamicModule, LazyModuleImport, ModuleBase, ModuleSetup
+from ellar.core.context import ApplicationContext
 from ellar.core.modules import ModuleRefBase
 from ellar.di import EllarInjector, ProviderConfig
 from ellar.reflect import reflect
@@ -14,7 +15,6 @@ from ellar.threading.sync_worker import execute_async_context_manager
 from ellar.utils import get_name, get_unique_type
 from starlette.routing import BaseRoute, Host, Mount
 
-from .context import ApplicationContext
 from .main import App
 from .services import EllarAppService
 

--- a/ellar/core/__init__.py
+++ b/ellar/core/__init__.py
@@ -2,6 +2,7 @@ import typing as t
 
 from .conf import Config, ConfigDefaultTypesMixin
 from .connection import HTTPConnection, Request, WebSocket
+from .context import ApplicationContext, config, current_injector
 from .execution_context import ExecutionContext, HostContext
 from .guards import GuardConsumer
 from .interceptors import EllarInterceptorConsumer
@@ -29,6 +30,9 @@ __all__ = [
     "VersioningSchemes",
     "mount",
     "host",
+    "current_injector",
+    "config",
+    "ApplicationContext",
 ]
 
 

--- a/ellar/core/conf/app_settings_models.py
+++ b/ellar/core/conf/app_settings_models.py
@@ -11,13 +11,11 @@ from ellar.common.responses import JSONResponse, PlainTextResponse
 from ellar.common.serializer import Serializer, SerializerFilter
 from ellar.common.templating import JinjaLoaderType
 from ellar.common.types import ASGIApp, TReceive, TScope, TSend
-from ellar.core.versioning import DefaultAPIVersioning
+from ellar.core.conf.mixins import ConfigDefaultTypesMixin
 from ellar.pydantic import ENCODERS_BY_TYPE as encoders_by_type
 from ellar.pydantic import field_validator
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.websockets import WebSocketClose
-
-from .mixins import ConfigDefaultTypesMixin
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from ellar.app.main import App
@@ -69,7 +67,7 @@ class ConfigValidationSchema(Serializer, ConfigDefaultTypesMixin):
     JINJA_LOADERS: t.List[JinjaLoaderType] = []
 
     # Application route versioning scheme
-    VERSIONING_SCHEME: IAPIVersioning = DefaultAPIVersioning()
+    VERSIONING_SCHEME: t.Optional[IAPIVersioning] = None
 
     REDIRECT_SLASHES: bool = False
 

--- a/ellar/core/conf/config.py
+++ b/ellar/core/conf/config.py
@@ -3,11 +3,10 @@ import typing as t
 from ellar.common.compatible.dict import AttributeDictAccessMixin
 from ellar.common.constants import ELLAR_CONFIG_MODULE
 from ellar.common.types import VT
+from ellar.core.conf.app_settings_models import ConfigValidationSchema
+from ellar.core.conf.mixins import ConfigDefaultTypesMixin
 from ellar.utils.importer import import_from_string
 from starlette.config import environ
-
-from .app_settings_models import ConfigValidationSchema
-from .mixins import ConfigDefaultTypesMixin
 
 
 class ConfigRuntimeError(RuntimeError):

--- a/ellar/core/conf/mixins.py
+++ b/ellar/core/conf/mixins.py
@@ -31,7 +31,7 @@ class ConfigDefaultTypesMixin:
     JINJA_LOADERS: t.List[t.Union[JinjaLoaderType, t.Any]]
 
     # Application route versioning scheme
-    VERSIONING_SCHEME: IAPIVersioning
+    VERSIONING_SCHEME: t.Optional[IAPIVersioning]
 
     # Enable or Disable Application Router route searching by appending backslash
     REDIRECT_SLASHES: bool

--- a/ellar/core/connection/http.py
+++ b/ellar/core/connection/http.py
@@ -1,7 +1,7 @@
 import typing as t
 
 from ellar.common import Identity
-from ellar.common.constants import SCOPE_SERVICE_PROVIDER
+from ellar.core.context import current_injector
 from starlette.requests import (
     HTTPConnection as StarletteHTTPConnection,
 )
@@ -16,10 +16,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 class HTTPConnection(StarletteHTTPConnection):
     @property
     def service_provider(self) -> "EllarInjector":
-        assert (
-            SCOPE_SERVICE_PROVIDER in self.scope
-        ), "RequestServiceProviderMiddleware must be installed to access request.service_provider"
-        return t.cast("EllarInjector", self.scope[SCOPE_SERVICE_PROVIDER])
+        return current_injector
 
     @property
     def user(self) -> Identity:

--- a/ellar/core/context.py
+++ b/ellar/core/context.py
@@ -5,7 +5,7 @@ from types import TracebackType
 
 from ellar.common.constants import ELLAR_CONFIG_MODULE
 from ellar.common.logging import logger
-from ellar.core import Config
+from ellar.core.conf import Config
 from ellar.di import EllarInjector
 from ellar.events import app_context_started, app_context_teardown
 from ellar.utils.functional import SimpleLazyObject, empty

--- a/ellar/core/execution_context/host.py
+++ b/ellar/core/execution_context/host.py
@@ -8,12 +8,12 @@ from ellar.common import (
     IWebSocketHostContext,
 )
 from ellar.common.compatible import cached_property
-from ellar.common.constants import SCOPE_SERVICE_PROVIDER
 from ellar.common.interfaces import IHostContext
 from ellar.common.types import TReceive, TScope, TSend
+from ellar.core.context import current_injector
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from ellar.core.main import App
+    from ellar.app.main import App
     from ellar.di import EllarInjector
 
 
@@ -36,11 +36,7 @@ class HostContext(IHostContext):
         self.send = send
 
     def get_service_provider(self) -> "EllarInjector":
-        return self._service_provider
-
-    @cached_property
-    def _service_provider(self) -> "EllarInjector":
-        return self.scope[SCOPE_SERVICE_PROVIDER]  # type:ignore[no-any-return]
+        return current_injector
 
     @cached_property
     def _get_websocket_context(self) -> IWebSocketHostContext:

--- a/ellar/core/middleware/__init__.py
+++ b/ellar/core/middleware/__init__.py
@@ -1,5 +1,4 @@
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware
-from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.gzip import GZipMiddleware as GZipMiddleware
 from starlette.middleware.httpsredirect import (
     HTTPSRedirectMiddleware as HTTPSRedirectMiddleware,
@@ -9,7 +8,7 @@ from starlette.middleware.trustedhost import (
 )
 from starlette.middleware.wsgi import WSGIMiddleware as WSGIMiddleware
 
-from .di import RequestServiceProviderMiddleware
+from .errors import ServerErrorMiddleware
 from .exceptions import ExceptionMiddleware
 from .function import FunctionBasedMiddleware
 from .middleware import EllarMiddleware as Middleware
@@ -26,5 +25,5 @@ __all__ = [
     "TrustedHostMiddleware",
     "WSGIMiddleware",
     "RequestVersioningMiddleware",
-    "RequestServiceProviderMiddleware",
+    "ServerErrorMiddleware",
 ]

--- a/ellar/core/middleware/exceptions.py
+++ b/ellar/core/middleware/exceptions.py
@@ -1,13 +1,13 @@
 import typing as t
 
-from ellar.common.constants import SCOPE_SERVICE_PROVIDER
 from ellar.common.interfaces import IHostContextFactory
 from ellar.common.types import ASGIApp, TMessage, TReceive, TScope, TSend
+from ellar.core.context import current_injector
 from ellar.core.exceptions import ExceptionMiddlewareService
 from starlette.exceptions import HTTPException
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from ellar.di import EllarInjector
+    pass
 
 
 class ExceptionMiddleware:
@@ -57,11 +57,7 @@ class ExceptionMiddleware:
                 msg = "Caught handled exception, but response already started."
                 raise RuntimeError(msg) from exc
 
-            service_provider: "EllarInjector" = t.cast(
-                "EllarInjector", scope[SCOPE_SERVICE_PROVIDER]
-            )
-
-            context_factory = service_provider.get(IHostContextFactory)
+            context_factory = current_injector.get(IHostContextFactory)
             context = context_factory.create_context(scope)
 
             if context.get_type() == "http":

--- a/ellar/core/middleware/middleware.py
+++ b/ellar/core/middleware/middleware.py
@@ -2,6 +2,7 @@ import typing as t
 
 from ellar.common.interfaces import IEllarMiddleware
 from ellar.common.types import ASGIApp
+from ellar.core.context import current_injector
 from ellar.di import EllarInjector, injectable
 from ellar.utils import build_init_kwargs
 from starlette.middleware import Middleware
@@ -22,8 +23,6 @@ class EllarMiddleware(Middleware, IEllarMiddleware):
 
     @t.no_type_check
     def __call__(self, app: ASGIApp, *args: t.Any, **kwargs: t.Any) -> T:
-        from ellar.app.context import current_injector
-
         kwargs.update(app=app)
         if "ellar_injector" in kwargs:
             injector: EllarInjector = kwargs.pop("ellar_injector")

--- a/ellar/core/middleware/versioning.py
+++ b/ellar/core/middleware/versioning.py
@@ -3,7 +3,7 @@ import typing as t
 from ellar.common.constants import SCOPE_API_VERSIONING_RESOLVER
 from ellar.common.types import TReceive, TScope, TSend
 from ellar.core.conf import Config
-from ellar.core.versioning import BaseAPIVersioning
+from ellar.core.versioning import BaseAPIVersioning, DefaultAPIVersioning
 from starlette.types import ASGIApp
 
 
@@ -18,10 +18,12 @@ class RequestVersioningMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if self.config.VERSIONING_SCHEME:
-            scheme = t.cast(BaseAPIVersioning, self.config.VERSIONING_SCHEME)
+        scheme = (
+            t.cast(BaseAPIVersioning, self.config.VERSIONING_SCHEME)
+            or DefaultAPIVersioning()
+        )
 
-            version_scheme_resolver = scheme.get_version_resolver(scope)
-            version_scheme_resolver.resolve()
-            scope[SCOPE_API_VERSIONING_RESOLVER] = version_scheme_resolver
+        version_scheme_resolver = scheme.get_version_resolver(scope)
+        version_scheme_resolver.resolve()
+        scope[SCOPE_API_VERSIONING_RESOLVER] = version_scheme_resolver
         await self.app(scope, receive, send)

--- a/ellar/core/router_builders/module_router.py
+++ b/ellar/core/router_builders/module_router.py
@@ -2,19 +2,23 @@ import typing as t
 
 from ellar.common import ModuleRouter
 from ellar.common.constants import CONTROLLER_OPERATION_HANDLER_KEY
-from ellar.core.routing import EllarMount, RouteCollection
+from ellar.core.routing import EllarMount
 from ellar.core.routing.utils import build_route_parameters
 from ellar.reflect import reflect
-from starlette.routing import Router
 
 from .base import RouterBuilder
+
+T_ = t.TypeVar("T_")
 
 
 class ModuleRouterBuilder(RouterBuilder, controller_type=ModuleRouter):
     @classmethod
     def build(
-        cls, controller_type: t.Union[ModuleRouter, t.Any], **kwargs: t.Any
-    ) -> EllarMount:
+        cls,
+        controller_type: t.Union[ModuleRouter, t.Any],
+        base_route_type: t.Type[t.Union[EllarMount, T_]] = EllarMount,
+        **kwargs: t.Any,
+    ) -> t.Union[T_, EllarMount]:
         if controller_type.get_pre_build_routes():
             routes = build_route_parameters(
                 controller_type.get_pre_build_routes(), controller_type.control_type
@@ -24,11 +28,8 @@ class ModuleRouterBuilder(RouterBuilder, controller_type=ModuleRouter):
                 CONTROLLER_OPERATION_HANDLER_KEY, controller_type.control_type
             )
 
-        app = Router()
-        app.routes = RouteCollection(routes)  # type:ignore
-
         controller_type.clear_pre_build_routes()
-        return EllarMount(**controller_type.get_mount_init(), app=app)
+        return base_route_type(**controller_type.get_mount_init(), routes=routes)  # type:ignore[call-arg]
 
     @classmethod
     def check_type(cls, controller_type: t.Union[t.Type, t.Any]) -> None:

--- a/ellar/core/routing/mount.py
+++ b/ellar/core/routing/mount.py
@@ -26,8 +26,8 @@ if t.TYPE_CHECKING:
 class EllarMount(StarletteMount):
     def __init__(
         self,
-        *,
         path: str,
+        *,
         routes: t.Optional[t.Sequence[t.Union[BaseRoute]]] = None,
         control_type: t.Optional[t.Type] = None,
         name: t.Optional[str] = None,

--- a/ellar/core/routing/route_collections.py
+++ b/ellar/core/routing/route_collections.py
@@ -6,6 +6,8 @@ from ellar.common.logging import logger
 from ellar.utils import generate_controller_operation_unique_id
 from starlette.routing import BaseRoute, Host, Mount
 
+from .utils import build_route_handler
+
 
 class RouteCollection(t.Sequence[BaseRoute]):
     __slots__ = ("_routes", "_served_routes")
@@ -54,7 +56,13 @@ class RouteCollection(t.Sequence[BaseRoute]):
 
     def _add_operation(self, operation: t.Union[BaseRoute]) -> None:
         if not isinstance(operation, BaseRoute):
-            logger.warning("Tried Adding an operation that is not supported.")
+            operations: t.Any = build_route_handler(operation)
+
+            for op in operations or []:
+                if not isinstance(op, BaseRoute):
+                    logger.warning("Tried Adding an operation that is not supported.")
+                    continue
+                self._add_operation(op)
             return
 
         _methods = getattr(operation, "methods", {"WS"})

--- a/ellar/reflect/_reflect.py
+++ b/ellar/reflect/_reflect.py
@@ -102,10 +102,14 @@ class _Reflect:
 
     def delete_metadata(
         self, metadata_key: str, target: t.Union[t.Type, t.Callable]
-    ) -> None:
+    ) -> t.Any:
         target_metadata = self._get_or_create_metadata(target)
         if target_metadata and metadata_key in target_metadata:
-            target_metadata.pop(metadata_key)
+            value = target_metadata.pop(metadata_key)
+            if isinstance(value, (list, set, tuple, dict)):
+                # return immutable value
+                return type(value)(value)
+            return value
 
     def _get_or_create_metadata(
         self, target: t.Union[t.Type, t.Callable], create: bool = False

--- a/ellar/socket_io/factory.py
+++ b/ellar/socket_io/factory.py
@@ -56,7 +56,10 @@ class GatewayRouterFactory(RouterBuilder, controller_type=type(GatewayBase)):
 
     @classmethod
     def build(
-        cls, controller_type: t.Union[t.Type[GatewayBase], t.Any], **kwargs: t.Any
+        cls,
+        controller_type: t.Union[t.Type[GatewayBase], t.Any],
+        base_route_type: t.Type[Mount] = Mount,
+        **kwargs: t.Any,
     ) -> "Mount":
         name = reflect.get_metadata_or_raise_exception(
             GATEWAY_METADATA.NAME, controller_type
@@ -92,7 +95,7 @@ class GatewayRouterFactory(RouterBuilder, controller_type=type(GatewayBase)):
                 )
                 SocketMessageOperation(controller_type, message, socket_server, handler)
 
-        return Mount(app=SocketIOASGIApp(socket_server), path=path, name=name)
+        return base_route_type(app=SocketIOASGIApp(socket_server), path=path, name=name)
 
     @classmethod
     def check_type(cls, controller_type: t.Union[t.Type, t.Any]) -> None:

--- a/tests/test_application/test_app_context.py
+++ b/tests/test_application/test_app_context.py
@@ -83,7 +83,7 @@ async def test_current_config_works_(anyio_backend):
         return a + b
 
     app = tm.create_application()
-    app.router.append(add)
+    app.router.add_route(add)
 
     async with app.application_context():
         res = tm.get_test_client().post("/", json={"a": 1, "b": 4})

--- a/tests/test_application/test_app_context.py
+++ b/tests/test_application/test_app_context.py
@@ -2,9 +2,9 @@ import logging
 
 import pytest
 from ellar.app import App, config, current_injector
-from ellar.app.context import ApplicationContext
 from ellar.common import Body, post
 from ellar.core import Config
+from ellar.core.context import ApplicationContext
 from ellar.testing import Test
 
 

--- a/tests/test_application/test_app_methods.py
+++ b/tests/test_application/test_app_methods.py
@@ -14,7 +14,6 @@ from ellar.core import Config
 from ellar.core.connection import Request
 from ellar.core.services.reflector import Reflector
 from ellar.core.versioning import (
-    DefaultAPIVersioning,
     UrlPathAPIVersioning,
 )
 from ellar.core.versioning import (
@@ -103,8 +102,8 @@ class TestEllarApp:
 
     def test_app_enable_versioning_and_versioning_scheme(self):
         app = Test.create_test_module().create_application()
-        assert app.config.VERSIONING_SCHEME
-        assert isinstance(app.config.VERSIONING_SCHEME, DefaultAPIVersioning)
+        assert app.config.VERSIONING_SCHEME is None
+        # assert isinstance(app.config.VERSIONING_SCHEME, DefaultAPIVersioning)
 
         app.enable_versioning(schema=VERSIONING.URL)
         assert isinstance(app.config.VERSIONING_SCHEME, UrlPathAPIVersioning)

--- a/tests/test_application/test_app_methods.py
+++ b/tests/test_application/test_app_methods.py
@@ -34,7 +34,7 @@ class TestEllarApp:
             await res(*ctx.get_args())
 
         app = AppFactory.create_app()
-        app.router.append(homepage)
+        app.router.add_route(homepage)
         client = TestClient(app)
         response = client.get("/")
         assert response.status_code == 200
@@ -47,7 +47,7 @@ class TestEllarApp:
             return res
 
         app = AppFactory.create_app()
-        app.router.append(homepage)
+        app.router.add_route(homepage)
         result = app.url_path_for("homepage")
         assert result == "/homepage-url"
 
@@ -156,7 +156,7 @@ class TestEllarApp:
         def raise_custom_exception():
             raise CustomException("Raised an Exception")
 
-        app.router.append(raise_custom_exception)
+        app.router.add_route(raise_custom_exception)
         client = TestClient(app)
         res = client.get("/404")
         assert res.status_code == 404

--- a/tests/test_application/test_cors.py
+++ b/tests/test_application/test_cors.py
@@ -18,7 +18,7 @@ def test_cors_allow_all():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     # Test pre-flight response
@@ -73,7 +73,7 @@ def test_cors_allow_all_except_credentials():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -119,7 +119,7 @@ def test_cors_allow_specific_origin():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -165,7 +165,7 @@ def test_cors_disallowed_preflight():
     )
     app = tm.create_application()
 
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     # Test pre-flight response
@@ -202,7 +202,7 @@ def test_preflight_allows_request_origin_if_origins_wildcard_and_credentials_all
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -231,7 +231,7 @@ def test_cors_preflight_allow_all_methods():
     )
     app = tm.create_application()
 
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     headers = {
@@ -254,7 +254,7 @@ def test_cors_allow_all_methods():
         config_module={"CORS_ALLOW_ORIGINS": ["*"], "CORS_ALLOW_METHODS": ["*"]}
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=methods)(homepage))
+    app.router.add_route(http_route(methods=methods)(homepage))
     client = tm.get_test_client()
 
     headers = {"Origin": "https://example.org"}
@@ -279,7 +279,7 @@ def test_cors_allow_origin_regex():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -346,7 +346,7 @@ def test_cors_allow_origin_regex_fullmatch():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -375,7 +375,7 @@ def test_cors_credentialed_requests_return_specific_origin():
 
     tm = Test.create_test_module(config_module={"CORS_ALLOW_ORIGINS": ["*"]})
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     # Test credentialed request
@@ -395,7 +395,7 @@ def test_cors_vary_header_defaults_to_origin():
         config_module={"CORS_ALLOW_ORIGINS": ["https://example.org"]}
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -414,7 +414,7 @@ def test_cors_vary_header_is_not_set_for_non_credentialed_request():
 
     tm = Test.create_test_module(config_module={"CORS_ALLOW_ORIGINS": ["*"]})
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -431,7 +431,7 @@ def test_cors_vary_header_is_properly_set_for_credentialed_request():
 
     tm = Test.create_test_module(config_module={"CORS_ALLOW_ORIGINS": ["*"]})
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     response = client.get(
@@ -451,7 +451,7 @@ def test_cors_vary_header_is_properly_set_when_allow_origins_is_not_wildcard():
         config_module={"CORS_ALLOW_ORIGINS": ["https://example.org"]}
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
 
     client = tm.get_test_client()
 
@@ -472,7 +472,7 @@ def test_cors_allowed_origin_does_not_leak_between_credentialed_requests():
         }
     )
     app = tm.create_application()
-    app.router.append(http_route(methods=["GET"])(homepage))
+    app.router.add_route(http_route(methods=["GET"])(homepage))
     client = tm.get_test_client()
 
     response = client.get("/", headers={"Origin": "https://someplace.org"})

--- a/tests/test_application/test_starlette_compatibility.py
+++ b/tests/test_application/test_starlette_compatibility.py
@@ -123,7 +123,7 @@ class TestStarletteCompatibility:
             raise RuntimeError()
 
         app = AppFactory.create_app()
-        app.router.append(homepage)
+        app.router.add_route(homepage)
         app.debug = True
 
         client = TestClient(app, raise_server_exceptions=False)
@@ -139,7 +139,7 @@ class TestStarletteCompatibility:
             raise RuntimeError()
 
         app = AppFactory.create_app()
-        app.router.append(homepage)
+        app.router.add_route(homepage)
         app.debug = True
 
         client = TestClient(app, raise_server_exceptions=False)

--- a/tests/test_application/test_trusted_host.py
+++ b/tests/test_application/test_trusted_host.py
@@ -13,7 +13,7 @@ def test_trusted_host_middleware(test_client_factory):
         config_module={"ALLOWED_HOSTS": ["testserver", "*.testserver"]}
     )
     app = tm.create_application()
-    app.router.append(homepage)
+    app.router.add_route(homepage)
 
     assert app.debug is False
 
@@ -40,7 +40,7 @@ def test_trusted_host_middleware_works_for_debug_true(test_client_factory):
         config_module={"ALLOWED_HOSTS": ["testserver", "*.testserver"]}
     )
     app = tm.create_application()
-    app.router.append(homepage)
+    app.router.add_route(homepage)
 
     assert app.debug is False
     app.debug = True
@@ -71,7 +71,7 @@ def test_www_redirect(test_client_factory):
 
     tm = Test.create_test_module(config_module={"ALLOWED_HOSTS": ["www.example.com"]})
     app = tm.create_application()
-    app.router.append(homepage)
+    app.router.add_route(homepage)
 
     client = tm.get_test_client(base_url="https://example.com")
     response = client.get("/")

--- a/tests/test_auth/test_guards/test_auth_guards.py
+++ b/tests/test_auth/test_guards/test_auth_guards.py
@@ -117,7 +117,7 @@ for _path, auth in [
     def auth_demo_endpoint(request: Inject[Request]):
         return {"authentication": request.user}
 
-    app.router.append(auth_demo_endpoint)
+    app.router.add_route(auth_demo_endpoint)
 
 client = TestClient(app)
 
@@ -273,7 +273,7 @@ def test_global_guard_case_1_works():
     def _auth_demo_endpoint(request: Inject[Request]):
         return {"authentication": request.user}
 
-    _app.router.append(_auth_demo_endpoint)
+    _app.router.add_route(_auth_demo_endpoint)
     _client = TestClient(_app)
     res = _client.get("/global")
 
@@ -292,7 +292,7 @@ def test_global_guard_case_2_works():
     def _auth_demo_endpoint(request: Request):
         return {"authentication": request.user}
 
-    _app.router.append(_auth_demo_endpoint)
+    _app.router.add_route(_auth_demo_endpoint)
     _client = TestClient(_app)
     res = _client.get("/global")
 
@@ -332,7 +332,7 @@ def test_if_an_auth_guard_return_converts_to_identity(
         assert request.user.is_authenticated == is_authenticated
         return {"authentication": request.user}
 
-    _app.router.append(_auth_demo_endpoint)
+    _app.router.add_route(_auth_demo_endpoint)
     _client = TestClient(_app)
     res = _client.get(
         "/global",

--- a/tests/test_auth/test_session/test_session_basic.py
+++ b/tests/test_auth/test_session/test_session_basic.py
@@ -12,7 +12,7 @@ def homepage(req: Inject[Request]):
 
 
 tm = Test.create_test_module()
-tm.create_application().router.append(homepage)
+tm.create_application().router.add_route(homepage)
 
 
 def test_session_object_raise_an_exception():
@@ -27,7 +27,7 @@ def test_session_object_raise_an_exception():
 def test_session_object_raise_an_exception_case_2():
     tm_case_2 = Test.create_test_module(config_module={"SESSION_DISABLED": True})
     tm_case_2.override_provider(SessionStrategy, use_class=SessionClientStrategy)
-    tm_case_2.create_application().router.append(homepage)
+    tm_case_2.create_application().router.add_route(homepage)
     session_service = tm_case_2.get(SessionStrategy)
     assert isinstance(session_service, SessionClientStrategy)
 

--- a/tests/test_conf/test_default_conf.py
+++ b/tests/test_conf/test_default_conf.py
@@ -4,7 +4,7 @@ import pytest
 from ellar.common.constants import ELLAR_CONFIG_MODULE
 from ellar.core.conf import Config, ConfigDefaultTypesMixin
 from ellar.core.conf.config import ConfigRuntimeError
-from ellar.core.versioning import DefaultAPIVersioning, UrlPathAPIVersioning
+from ellar.core.versioning import UrlPathAPIVersioning
 from ellar.pydantic import ENCODERS_BY_TYPE
 from jinja2.loaders import FileSystemLoader
 from starlette.responses import JSONResponse
@@ -40,7 +40,8 @@ def test_default_configurations():
 
     assert config.JINJA_TEMPLATES_OPTIONS == {}
 
-    assert isinstance(config.VERSIONING_SCHEME, DefaultAPIVersioning)
+    assert config.VERSIONING_SCHEME is None
+    # assert isinstance(config.VERSIONING_SCHEME, DefaultAPIVersioning)
     assert config.REDIRECT_SLASHES is False
 
     assert config.STATIC_FOLDER_PACKAGES == []

--- a/tests/test_controller/test_route_collection.py
+++ b/tests/test_controller/test_route_collection.py
@@ -210,15 +210,16 @@ def test_route_collection_create_control_type(collection_model):
     def endpoint_once():
         pass
 
+    def invalid_endpoint():
+        pass
+
     assert reflect.get_metadata(CONTROLLER_CLASS_KEY, endpoint_once) is None
-    operation = reflect.get_metadata(CONTROLLER_OPERATION_HANDLER_KEY, endpoint_once)
+    assert reflect.get_metadata(CONTROLLER_OPERATION_HANDLER_KEY, endpoint_once) is None
 
-    collection_model([operation])
+    collection_model([endpoint_once])
     assert not isinstance(
         reflect.get_metadata(CONTROLLER_CLASS_KEY, endpoint_once), list
     )
 
-    collection_model([operation])
-    assert not isinstance(
-        reflect.get_metadata(CONTROLLER_CLASS_KEY, endpoint_once), list
-    )
+    collection = collection_model([invalid_endpoint])
+    assert len(collection) == 0

--- a/tests/test_exceptions/test_api_exception.py
+++ b/tests/test_exceptions/test_api_exception.py
@@ -27,7 +27,7 @@ def exception_():
     _exception_runner.run()
 
 
-test_module.create_application().router.append(exception_)
+test_module.create_application().router.add_route(exception_)
 client = test_module.get_test_client()
 
 

--- a/tests/test_exceptions/test_custom_exceptions.py
+++ b/tests/test_exceptions/test_custom_exceptions.py
@@ -133,7 +133,7 @@ def test_custom_exception_works():
 
     tm = Test.create_test_module()
     app = tm.create_application()
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     app.add_exception_handler(NewExceptionHandler())
 
     client = tm.get_test_client()
@@ -149,7 +149,7 @@ def test_exception_override_works():
 
     tm = Test.create_test_module()
     app = tm.create_application()
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     app.add_exception_handler(OverrideAPIExceptionHandler())
 
     client = tm.get_test_client()
@@ -175,7 +175,7 @@ def test_500_error_as_a_function(exception_handler):
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     app.add_exception_handler(exception_handler)
 
     client = tm.get_test_client(raise_server_exceptions=False)
@@ -192,7 +192,7 @@ def test_raise_default_http_exception():
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     client = tm.get_test_client()
     res = client.get("/")
     assert res.status_code == 400
@@ -208,7 +208,7 @@ def test_raise_default_http_exception_for_204_and_304(status_code):
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
+    app.router.add_route(homepage)
 
     client = tm.get_test_client()
     res = client.get("/")
@@ -240,7 +240,7 @@ def test_application_add_exception_handler():
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     app.add_exception_handler(OverrideHTTPException())
 
     client = tm.get_test_client()
@@ -258,7 +258,7 @@ def test_application_http_exception_handler_raise_exception_for_returning_none()
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
+    app.router.add_route(homepage)
     app.add_exception_handler(RuntimeHTTPException())
     with pytest.raises(
         RuntimeError, match="HTTP ExceptionHandler must return a response."
@@ -310,8 +310,8 @@ def test_http_exception_handler_case_1(exc):
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage)
-    app.router.append(homepage_2)
+    app.router.add_route(homepage)
+    app.router.add_route(homepage_2)
     client = tm.get_test_client()
 
     res = client.get("/case_1")
@@ -337,7 +337,7 @@ def test_ws_exception_handler():
     tm = Test.create_test_module()
     app = tm.create_application()
 
-    app.router.append(homepage_3)
+    app.router.add_route(homepage_3)
     client = tm.get_test_client()
 
     with client.websocket_connect("/ws"):

--- a/tests/test_interceptors/test_interceptor.py
+++ b/tests/test_interceptors/test_interceptor.py
@@ -95,7 +95,7 @@ def test_global_guard_works():
     def _interceptor_demo_endpoint():
         return {"message": "intercepted okay"}
 
-    app.router.append(_interceptor_demo_endpoint)
+    app.router.add_route(_interceptor_demo_endpoint)
     app.use_global_interceptors(Interceptor1(), InterceptCustomException)
 
     _client = tm.get_test_client()

--- a/tests/test_middleware/test_exception_middleware.py
+++ b/tests/test_middleware/test_exception_middleware.py
@@ -14,7 +14,7 @@ def test_exception_after_response_sent(test_client_factory):
         # raise RuntimeError("Something went wrong")
 
     app = AppFactory.create_app()
-    app.router.append(home)
+    app.router.add_route(home)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):

--- a/tests/test_middleware/test_service_provider_middleware.py
+++ b/tests/test_middleware/test_service_provider_middleware.py
@@ -3,19 +3,16 @@ import json
 import pytest
 from ellar.app.services import EllarAppService
 from ellar.common import IHostContextFactory
-from ellar.common.constants import SCOPE_SERVICE_PROVIDER
 from ellar.common.exceptions import HostContextException
-from ellar.core import Config
-from ellar.core.middleware import RequestServiceProviderMiddleware
+from ellar.core import ApplicationContext, Config, current_injector
+from ellar.core.middleware import ServerErrorMiddleware
 from ellar.di import EllarInjector
+from ellar.threading.sync_worker import execute_async_context_manager
 
 from ..injector_module import Configuration, DummyModule
 
 
 async def assert_service_provider_app(scope, receive, send):
-    assert scope[SCOPE_SERVICE_PROVIDER]
-
-    service_provider = scope[SCOPE_SERVICE_PROVIDER]
     await send(
         {
             "type": "http.response.start",
@@ -23,8 +20,8 @@ async def assert_service_provider_app(scope, receive, send):
             "headers": [[b"content-type", b"application/json"]],
         }
     )
-    _config_repr = repr(service_provider.get(Configuration))
-    str_provider = service_provider.get(str)
+    _config_repr = repr(current_injector.get(Configuration))
+    str_provider = current_injector.get(str)
     await send(
         {
             "type": "http.response.body",
@@ -36,10 +33,7 @@ async def assert_service_provider_app(scope, receive, send):
 
 
 async def assert_iexecute_context_app(scope, receive, send):
-    assert scope[SCOPE_SERVICE_PROVIDER]
-
-    service_provider = scope[SCOPE_SERVICE_PROVIDER]
-    host_context_factory: IHostContextFactory = service_provider.get(
+    host_context_factory: IHostContextFactory = current_injector.get(
         IHostContextFactory
     )
     host_context = host_context_factory.create_context(scope, receive, send)
@@ -63,16 +57,13 @@ async def assert_iexecute_context_app(scope, receive, send):
 
 
 async def assert_iexecute_context_app_websocket(scope, receive, send):
-    assert scope[SCOPE_SERVICE_PROVIDER]
-
-    service_provider = scope[SCOPE_SERVICE_PROVIDER]
-    host_context_factory: IHostContextFactory = service_provider.get(
+    host_context_factory: IHostContextFactory = current_injector.get(
         IHostContextFactory
     )
     host_context = host_context_factory.create_context(scope, receive, send)
 
     websocket = host_context.switch_to_websocket().get_client()
-    assert service_provider is host_context.get_service_provider()
+    assert current_injector is host_context.get_service_provider()
 
     with pytest.raises(HostContextException):
         host_context.switch_to_http_connection().get_request()
@@ -88,12 +79,14 @@ async def assert_iexecute_context_app_websocket(scope, receive, send):
 def test_di_middleware(test_client_factory):
     injector_ = EllarInjector()
     injector_.container.install(DummyModule)
-    asgi_app = RequestServiceProviderMiddleware(
+    asgi_app = ServerErrorMiddleware(
         assert_service_provider_app, debug=False, injector=injector_
     )
     EllarAppService(injector_, config=Config()).register_core_services()
-    client = test_client_factory(asgi_app)
-    response = client.get("/")
+
+    with execute_async_context_manager(ApplicationContext(injector_)):
+        client = test_client_factory(asgi_app)
+        response = client.get("/")
 
     assert response.status_code == 200
     data = response.json()
@@ -103,13 +96,13 @@ def test_di_middleware(test_client_factory):
 
 def test_di_middleware_execution_context_initialization(test_client_factory):
     injector_ = EllarInjector()
-    asgi_app = RequestServiceProviderMiddleware(
+    asgi_app = ServerErrorMiddleware(
         assert_iexecute_context_app, debug=False, injector=injector_
     )
     EllarAppService(injector_, config=Config()).register_core_services()
-
-    client = test_client_factory(asgi_app)
-    response = client.get("/")
+    with execute_async_context_manager(ApplicationContext(injector_)):
+        client = test_client_factory(asgi_app)
+        response = client.get("/")
 
     assert response.status_code == 200
     data = response.json()
@@ -118,12 +111,12 @@ def test_di_middleware_execution_context_initialization(test_client_factory):
 
 def test_di_middleware_execution_context_initialization_websocket(test_client_factory):
     injector_ = EllarInjector()
-    asgi_app = RequestServiceProviderMiddleware(
+    asgi_app = ServerErrorMiddleware(
         assert_iexecute_context_app_websocket, debug=False, injector=injector_
     )
     EllarAppService(injector_, config=Config()).register_core_services()
-
     client = test_client_factory(asgi_app)
-    with client.websocket_connect("/") as session:
-        text = session.receive_text()
-        assert text == "Hello, world!"
+    with execute_async_context_manager(ApplicationContext(injector_)):
+        with client.websocket_connect("/") as session:
+            text = session.receive_text()
+            assert text == "Hello, world!"

--- a/tests/test_routing/test_body_schema.py
+++ b/tests/test_routing/test_body_schema.py
@@ -21,7 +21,7 @@ async def create_item(
     return product
 
 
-tm.create_application().router.append(create_item)
+tm.create_application().router.add_route(create_item)
 
 openapi_schema = {
     "openapi": "3.1.0",

--- a/tests/test_routing/test_body_schema_extra_properties.py
+++ b/tests/test_routing/test_body_schema_extra_properties.py
@@ -24,7 +24,7 @@ def foo(items: Items_):
 
 
 app = tm.create_application()
-app.router.append(foo)
+app.router.add_route(foo)
 client = tm.get_test_client()
 
 

--- a/tests/test_routing/test_body_union_schema.py
+++ b/tests/test_routing/test_body_union_schema.py
@@ -44,9 +44,9 @@ def alias_qty(
 
 
 app = tm.create_application()
-app.router.append(save_union_body_and_embedded_body)
-app.router.append(embed_qty)
-app.router.append(alias_qty)
+app.router.add_route(save_union_body_and_embedded_body)
+app.router.add_route(embed_qty)
+app.router.add_route(alias_qty)
 
 client = tm.get_test_client()
 
@@ -291,7 +291,7 @@ def test_alias_with_more_body():
 
     _tm = Test.create_test_module()
     _app = _tm.create_application()
-    _app.router.append(create_item)
+    _app.router.add_route(create_item)
 
     _client = _tm.get_test_client()
 

--- a/tests/test_routing/test_extra_args.py
+++ b/tests/test_routing/test_extra_args.py
@@ -93,7 +93,7 @@ def query_params_extra(
     return filters.dict()
 
 
-app.router.append(query_params_extra)
+app.router.add_route(query_params_extra)
 
 openapi_schema = {
     "openapi": "3.1.0",
@@ -237,7 +237,7 @@ def test_extra_args_as_grouped_fields():
     ):
         return {}
 
-    tm.create_application().router.append(query_params_extra)
+    tm.create_application().router.add_route(query_params_extra)
     client = tm.get_test_client()
     response = client.get(
         "/test-grouped?from=1&to=2&range=20&foo=1&range2=50&query1=somequery1&query2=somequery2"

--- a/tests/test_routing/test_formparsers.py
+++ b/tests/test_routing/test_formparsers.py
@@ -397,7 +397,7 @@ def test_form_file_data_as_bytes(tmpdir):
         }
 
     new_tm = Test.create_test_module()
-    new_tm.create_application().router.append(form_file_as_bytes)
+    new_tm.create_application().router.add_route(form_file_as_bytes)
     client = new_tm.get_test_client()
 
     with open(path, "rb") as f:
@@ -421,7 +421,7 @@ def test_form_file_data_as_list_of_bytes(tmpdir):
         }
 
     new_tm = Test.create_test_module()
-    new_tm.create_application().router.append(form_file_as_bytes)
+    new_tm.create_application().router.add_route(form_file_as_bytes)
     client = new_tm.get_test_client()
 
     with open(path, "rb") as f:

--- a/tests/test_routing/test_module_mount.py
+++ b/tests/test_routing/test_module_mount.py
@@ -6,7 +6,7 @@ class ControlType:
 
 
 def test_module_mount_default_handler(test_client_factory):
-    mount = EllarMount("/", ControlType)
+    mount = EllarMount("/", control_type=ControlType)
     client = test_client_factory(mount.handle)
     res = client.get("/")
     assert res.status_code == 404

--- a/tests/test_routing/test_multi_body_errors.py
+++ b/tests/test_routing/test_multi_body_errors.py
@@ -25,7 +25,7 @@ def save_item_no_body(item: List[Item2]):
     return {"item": item}
 
 
-app.router.append(save_item_no_body)
+app.router.add_route(save_item_no_body)
 client = tm.get_test_client()
 
 

--- a/tests/test_routing/test_multi_query_errors.py
+++ b/tests/test_routing/test_multi_query_errors.py
@@ -18,7 +18,7 @@ def read_items(q: List[int] = Query(None)):
     return {"q": q}
 
 
-app.router.append(read_items)
+app.router.add_route(read_items)
 client = tm.get_test_client()
 
 

--- a/tests/test_routing/test_put_with_no_body_schema.py
+++ b/tests/test_routing/test_put_with_no_body_schema.py
@@ -15,7 +15,7 @@ def save_item_no_body(item_id: str):
     return {"item_id": item_id}
 
 
-app.router.append(save_item_no_body)
+app.router.add_route(save_item_no_body)
 client = tm.get_test_client()
 
 

--- a/tests/test_routing/test_route_endpoint_params.py
+++ b/tests/test_routing/test_route_endpoint_params.py
@@ -146,4 +146,4 @@ def test_multiple_annotation():
         def multiple_annotation(dep1: Annotated[str, Body(), Query()]):
             pass
 
-        tm.create_application().router.append(multiple_annotation)
+        tm.create_application().router.add_route(multiple_annotation)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -5,12 +5,12 @@ from enum import Enum
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
 
 import pytest
-from ellar.app.context import ApplicationContext
 from ellar.common.serializer.base import (
     Serializer,
     SerializerFilter,
     serialize_object,
 )
+from ellar.core.context import ApplicationContext
 from ellar.pydantic import as_pydantic_validator
 from ellar.testing import Test
 from pydantic import BaseModel, Field, RootModel

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -16,7 +16,7 @@ def test_websocket_url(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/123?a=abc") as websocket:
@@ -33,7 +33,7 @@ def test_websocket_binary_json(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/123?a=abc") as websocket:
@@ -50,7 +50,7 @@ def test_websocket_query_params(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/?a=abc&b=456") as websocket:
@@ -74,7 +74,7 @@ def test_websocket_headers(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -99,7 +99,7 @@ def test_websocket_port(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("ws://example.com:123/123?a=abc") as websocket:
@@ -116,7 +116,7 @@ def test_websocket_send_and_receive_text(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -134,7 +134,7 @@ def test_websocket_send_and_receive_bytes(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -152,7 +152,7 @@ def test_websocket_send_and_receive_json(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -169,7 +169,7 @@ def test_websocket_iter_text(test_client_factory):
             await websocket.send_text("Message was: " + _data)
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -186,7 +186,7 @@ def test_websocket_iter_bytes(test_client_factory):
             await websocket.send_bytes(b"Message was: " + data_)
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -203,7 +203,7 @@ def test_websocket_iter_json(test_client_factory):
             await websocket.send_json({"message": data_})
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -234,7 +234,7 @@ def test_websocket_concurrency_pattern(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -256,7 +256,7 @@ def test_client_close(test_client_factory):
             close_code = exc.code
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -271,7 +271,7 @@ def test_application_close(test_client_factory):
         await websocket.close(status.WS_1001_GOING_AWAY)
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -286,7 +286,7 @@ def test_rejected_connection(test_client_factory):
         await websocket.close(status.WS_1001_GOING_AWAY)
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(WebSocketDisconnect) as exc:
@@ -303,7 +303,7 @@ def test_subprotocol(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/", subprotocols=["soap", "wamp"]) as websocket:
@@ -317,7 +317,7 @@ def test_additional_headers(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -331,7 +331,7 @@ def test_no_additional_headers(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -344,7 +344,7 @@ def test_websocket_exception(test_client_factory):
         raise AssertionError()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(AssertionError):
@@ -360,7 +360,7 @@ def test_duplicate_close(test_client_factory):
         await websocket.close()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -377,7 +377,7 @@ def test_duplicate_disconnect(test_client_factory):
         message = await websocket.receive()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -392,7 +392,7 @@ def test_websocket_close_reason(test_client_factory) -> None:
         await websocket.close(code=status.WS_1001_GOING_AWAY, reason="Going Away")
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with client.websocket_connect("/") as websocket:
@@ -409,7 +409,7 @@ def test_send_json_invalid_mode(test_client_factory):
         await websocket.send_json({}, mode="invalid")
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -424,7 +424,7 @@ def test_receive_json_invalid_mode(test_client_factory):
         await websocket.receive_json(mode="invalid")
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -438,7 +438,7 @@ def test_receive_text_before_accept(test_client_factory):
         await websocket.receive_text()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -452,7 +452,7 @@ def test_receive_bytes_before_accept(test_client_factory):
         await websocket.receive_bytes()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -466,7 +466,7 @@ def test_receive_json_before_accept(test_client_factory):
         await websocket.receive_json()
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -480,7 +480,7 @@ def test_send_before_accept(test_client_factory):
         await websocket.send({"type": "websocket.send"})
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
@@ -495,7 +495,7 @@ def test_send_wrong_message_type(test_client_factory):
         await websocket.send({"type": "websocket.accept"})
 
     app = AppFactory.create_app()
-    app.router.append(ws_function)
+    app.router.add_route(ws_function)
 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -180,7 +180,7 @@ def test_websocket_setup_fails_when_using_body_without_handler():
         ):
             pass
 
-        tm.create_application().router.append(websocket_with_handler)
+        tm.create_application().router.add_route(websocket_with_handler)
 
 
 def test_websocket_endpoint_on_connect():


### PR DESCRIPTION
## What's changed
- Adapting `current_injector` around the app
- Refactored `EllarMount` and `ApplicationRouter` to support ModuleRouter and Controller build
- Moved `ApplicationContext` to `ellar.core` package