### PR TITLE
fix: Drop Global Guard as Provider

### DIFF
--- a/docs/security/authentication/auth-handler-strategy.md
+++ b/docs/security/authentication/auth-handler-strategy.md
@@ -1,0 +1,176 @@
+# **Authentication Schemes Strategy**
+
+Authentication scheme is another strategy for identifying the user who is using the application. The difference between it and
+and Guard strategy is your identification executed at middleware layer when processing incoming request while guard execution
+happens just before route function is executed.
+
+Ellar provides `BaseAuthenticationHandler` contract which defines what is required to set up any authentication strategy. 
+We are going to make some modifications on the existing project to see how we can achieve the same result and to show how authentication handlers in ellar.
+
+### Creating a JWT Authentication Handler
+Just like AuthGuard, we need to create its equivalent. But first we need to create a `auth_scheme.py` at the root level 
+of your application for us to define a `JWTAuthentication` handler. 
+
+
+```python title='prject_name/auth_scheme.py' linenums='1'
+import typing as t
+from ellar.common.serializer.guard import (
+    HTTPAuthorizationCredentials,
+)
+from ellar.auth import UserIdentity
+from ellar.auth.handlers import HttpBearerAuthenticationHandler
+from ellar.common import IHostContext
+from ellar.di import injectable
+from ellar_jwt import JWTService
+
+
+@injectable
+class JWTAuthentication(HttpBearerAuthenticationHandler):
+    def __init__(self, jwt_service: JWTService) -> None:
+        self.jwt_service = jwt_service
+
+    async def authentication_handler(
+        self,
+        context: IHostContext,
+        credentials: HTTPAuthorizationCredentials,
+    ) -> t.Optional[t.Any]:
+        # this function will be called by Identity Middleware but only when a `Bearer token` is found on the header request
+        try:
+            data = await self.jwt_service.decode_async(credentials.credentials)
+            return UserIdentity(auth_type=self.scheme, **data)
+        except Exception as ex:
+            # if we cant identity the user or token has expired, we return None.
+            return None
+```
+
+Let us make `JWTAuthentication` Handler available for ellar to use as shown below
+
+```python title='project_name.server.py' linenums='1'
+import os
+from ellar.common.constants import ELLAR_CONFIG_MODULE
+from ellar.app import AppFactory, use_authentication_schemes
+from ellar.core import LazyModuleImport as lazyLoad
+from .auth_scheme import JWTAuthentication
+
+
+application = AppFactory.create_from_app_module(
+    lazyLoad('project_name.root_module:ApplicationModule'),
+    config_module=os.environ.get(
+        ELLAR_CONFIG_MODULE, "project_name.config:DevelopmentConfig"
+    ),
+)
+use_authentication_schemes(JWTAuthentication)
+```
+Unlike guards, Authentication handlers are registered global by default as shown in the above illustration. 
+Also, we need to remove `GlobalGuard` registration we did in `AuthModule`, 
+so that we don't have too user identification checks.
+
+!!!note
+    In the above illustration, we added JWTAuthentication as a type.
+    This means DI will create JWTAuthentication instance.
+    We can use this method because we want `JWTService` to be injected when instantiating `JWTAuthentication`. 
+    But if you don't have any need for DI injection, you can use the below.
+    ```python
+    ...
+    application.add_authentication_schemes(JWTAuthentication())
+    ## OR
+    ## use_authentication_schemes(JWTAuthentication())
+    ```
+
+We need
+to refactor auth controller and mark `refresh_token` and `sign_in` function as public routes
+by using `SkipAuth` decorator from `ellar.auth` package.
+
+```python title='auth/controller.py' linenums='1'
+from ellar.common import Controller, ControllerBase, post, Body, get
+from ellar.auth import SkipAuth, AuthenticationRequired
+from ellar.openapi import ApiTags
+from .services import AuthService
+
+
+@AuthenticationRequired('JWTAuthentication')
+@Controller
+@ApiTags(name='Authentication', description='User Authentication Endpoints')
+class AuthController(ControllerBase):
+    def __init__(self, auth_service: AuthService) -> None:
+        self.auth_service = auth_service
+
+    @post("/login")
+    @SkipAuth()
+    async def sign_in(self, username: Body[str], password: Body[str]):
+        return await self.auth_service.sign_in(username=username, password=password)
+
+    @get("/profile")
+    async def get_profile(self):
+        return self.context.user
+    
+    @SkipAuth()
+    @post("/refresh")
+    async def refresh_token(self, payload: str = Body(embed=True)):
+        return await self.auth_service.refresh_token(payload)
+
+
+```
+In the above illustration,
+we decorated AuthController with `@AuthenticationRequired('JWTAuthentication')`
+to ensure we have authenticated user before executing any route function and, 
+we passed in `JWTAuthentication` as a parameter,
+which will be used in openapi doc to define the controller routes security scheme.
+
+It is importance to note that when using `AuthenticationHandler` approach,
+that you have
+to always use `AuthenticationRequired` decorator on route functions or controller
+that needs protected from anonymous users.
+
+But if you have a single form of authentication,
+you can register `AuthenticatedRequiredGuard` from `eellar.auth.guard` module globally
+just like we did in [applying guard globally](./guard-strategy.md#apply-authguard-globally)
+
+```python title='auth/module.py' linenums='1'
+from datetime import timedelta
+
+from ellar.app import use_global_guards
+from ellar.auth.guards import AuthenticatedRequiredGuard
+from ellar.common import Module
+from ellar.core import ModuleBase, LazyModuleImport as lazyLoad
+from ellar_jwt import JWTModule
+
+from .controllers import AuthController
+from .services import AuthService
+
+## Registers AuthenticatedRequiredGuard to the GLOBAL GUARDS
+use_global_guards(AuthenticatedRequiredGuard('JWTAuthentication', []))
+
+@Module(
+    modules=[
+        lazyLoad('project_name.users.module:UserModule'),
+        JWTModule.setup(
+            signing_secret_key="my_poor_secret_key_lol", lifetime=timedelta(minutes=5)
+        ),
+    ],
+    controllers=[AuthController],
+    providers=[AuthService],
+)
+class AuthModule(ModuleBase):
+    """
+    Auth Module
+    """
+```
+
+Still having the server running, we can test as before
+
+```shell
+$ # GET /auth/profile
+$ curl http://localhost:8000/auth/profile
+{"detail":"Forbidden"} # status_code=403
+
+$ # POST /auth/login
+$ curl -X POST http://localhost:8000/auth/login -d '{"username": "john", "password": "password"}' -H "Content-Type: application/json"
+{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2OTg3OTE0OTE..."}
+
+$ # GET /profile using access_token returned from previous step as bearer code
+$ curl http://localhost:8000/auth/profile -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2Vybm..."
+{"exp":1698793558,"iat":1698793258,"jti":"e96e94c5c3ef4fbbbd7c2468eb64534b","sub":1,"user_id":1,"username":"john", "id":null,"auth_type":"bearer"}
+
+```
+Source Code to this example is [here](https://github.com/python-ellar/ellar/tree/main/examples/04-auth-with-handlers)

--- a/docs/security/authentication/guard-strategy.md
+++ b/docs/security/authentication/guard-strategy.md
@@ -1,17 +1,17 @@
-# **Authentication**
+# **Authentication and Guard authentication**
 Authentication is an **essential** part of most applications. It refers to the methods and techniques used to verify the identity of users interacting with your application. There are many different approaches and strategies to handle authentication. The approach taken for any project depends on its particular application requirements.
 In this section, we shall go through different approaches to authentication in Ellar and how it will suit your authentication requirements.
 
 There are two ways in which user authentication and identification are processed in Ellar:
 
 - [Using Guards](#1-guard-authentication)
-- [Using Authentication Schemes](#2-authentication-schemes)
+- [Using Authentication Schemes](./auth-handler-strategy.md)
 
 ## **1. Guard Authentication**
 We have discussed in detail how Guards are used to protect a route and check for user authorizations, but we never really addressed how they can be used for authentication purposes. For this, we are going to illustrate JWT authentication using Guard
 
 !!!note 
-    Read more on [Guards](../overview/guards.md){target=_blank}
+    Read more on [Guards](../../overview/guards.md){target=_blank}
 
 Let's flesh out our requirements. For this use case, clients will start by authenticating with a username and password. 
 Once authenticated, the server will issue a JWT that can be sent as a bearer token in an authorization header on subsequent requests to prove authentication. 
@@ -239,9 +239,7 @@ from ellar.samples.modules import HomeModule
     modules=[HomeModule, lazyLoad('project_name.auth.module:AuthModule'),],
 )
 class ApplicationModule(ModuleBase):
-    @exception_handler(404)
-    def exception_404_handler(cls, ctx: IExecutionContext, exc: Exception) -> Response:
-        return JSONResponse(dict(detail="Resource not found."))
+    pass
 ```
 
 Then restart the server if it is not running.
@@ -435,7 +433,7 @@ With the above illustration refresh token mechanism is complete.
     There are ways of refreshing tokens. This was to illustrate how you can achieve it using ellar-jwt package.
 
 You can also vist [http://localhost:8000/docs](http://localhost:8000/docs)
-![Swagger UI](../img/auth_image.png)
+![Swagger UI](../../img/auth_image.png)
 
 ## **Apply AuthGuard Globally**
 
@@ -448,8 +446,8 @@ First, let us register `AuthGuard` a global guard in `AuthModule`.
 
 ```python title="auth/module.py" linenums="1"
 from datetime import timedelta
-
-from ellar.common import GlobalGuard, Module
+from ellar.app import use_global_guards
+from ellar.common import Module
 from ellar.core import ModuleBase, LazyModuleImport as lazyLoad
 from ellar.di import ProviderConfig
 from ellar_jwt import JWTModule
@@ -457,6 +455,10 @@ from ellar_jwt import JWTModule
 from .controllers import AuthController
 from .services import AuthService
 from .guards import AuthGuard
+
+## Registers AuthGuard in Application Config GLOBAL GUARDS
+use_global_guards(AuthGuard)
+
 
 @Module(
     modules=[
@@ -605,175 +607,3 @@ class AuthController(ControllerBase):
         return await self.auth_service.refresh_token(payload)
 ```
 Source Code to this example is [here](https://github.com/python-ellar/ellar/tree/main/examples/03-auth-with-guards)
-
-## **2. Authentication Schemes**
-
-Authentication scheme is another strategy for identifying the user who is using the application. The difference between it and
-and Guard strategy is your identification executed at middleware layer when processing incoming request while guard execution
-happens just before route function is executed.
-
-Ellar provides `BaseAuthenticationHandler` contract which defines what is required to set up any authentication strategy. 
-We are going to make some modifications on the existing project to see how we can achieve the same result and to show how authentication handlers in ellar.
-
-### Creating a JWT Authentication Handler
-Just like AuthGuard, we need to create its equivalent. But first we need to create a `auth_scheme.py` at the root level 
-of your application for us to define a `JWTAuthentication` handler. 
-
-
-```python title='prject_name/auth_scheme.py' linenums='1'
-import typing as t
-from ellar.common.serializer.guard import (
-    HTTPAuthorizationCredentials,
-)
-from ellar.auth import UserIdentity
-from ellar.auth.handlers import HttpBearerAuthenticationHandler
-from ellar.common import IHostContext
-from ellar.di import injectable
-from ellar_jwt import JWTService
-
-
-@injectable
-class JWTAuthentication(HttpBearerAuthenticationHandler):
-    def __init__(self, jwt_service: JWTService) -> None:
-        self.jwt_service = jwt_service
-
-    async def authentication_handler(
-        self,
-        context: IHostContext,
-        credentials: HTTPAuthorizationCredentials,
-    ) -> t.Optional[t.Any]:
-        # this function will be called by Identity Middleware but only when a `Bearer token` is found on the header request
-        try:
-            data = await self.jwt_service.decode_async(credentials.credentials)
-            return UserIdentity(auth_type=self.scheme, **data)
-        except Exception as ex:
-            # if we cant identity the user or token has expired, we return None.
-            return None
-```
-
-Let us make `JWTAuthentication` Handler available for ellar to use as shown below
-
-```python title='project_name.server.py' linenums='1'
-import os
-from ellar.common.constants import ELLAR_CONFIG_MODULE
-from ellar.app import AppFactory
-from ellar.core import LazyModuleImport as lazyLoad
-from .auth_scheme import JWTAuthentication
-
-application = AppFactory.create_from_app_module(
-    lazyLoad('project_name.root_module:ApplicationModule'),
-    config_module=os.environ.get(
-        ELLAR_CONFIG_MODULE, "project_name.config:DevelopmentConfig"
-    ),
-)
-application.add_authentication_schemes(JWTAuthentication)
-
-```
-Unlike guards, Authentication handlers are registered global by default as shown in the above illustration. 
-Also, we need to remove `GlobalGuard` registration we did in `AuthModule`, 
-so that we don't have too user identification checks.
-
-!!!note
-    In the above illustration, we added JWTAuthentication as a type.
-    This means DI will create JWTAuthentication instance.
-    We can use this method because we want `JWTService` to be injected when instantiating `JWTAuthentication`. 
-    But if you don't have any need for DI injection, you can use the below.
-    ```python
-    ...
-    application.add_authentication_schemes(JWTAuthentication())
-    ```
-
-We need
-to refactor auth controller and mark `refresh_token` and `sign_in` function as public routes
-by using `SkipAuth` decorator from `ellar.auth` package.
-
-```python title='auth/controller.py' linenums='1'
-from ellar.common import Controller, ControllerBase, post, Body, get
-from ellar.auth import SkipAuth, AuthenticationRequired
-from ellar.openapi import ApiTags
-from .services import AuthService
-
-
-@AuthenticationRequired('JWTAuthentication')
-@Controller
-@ApiTags(name='Authentication', description='User Authentication Endpoints')
-class AuthController(ControllerBase):
-    def __init__(self, auth_service: AuthService) -> None:
-        self.auth_service = auth_service
-
-    @post("/login")
-    @SkipAuth()
-    async def sign_in(self, username: Body[str], password: Body[str]):
-        return await self.auth_service.sign_in(username=username, password=password)
-
-    @get("/profile")
-    async def get_profile(self):
-        return self.context.user
-    
-    @SkipAuth()
-    @post("/refresh")
-    async def refresh_token(self, payload: str = Body(embed=True)):
-        return await self.auth_service.refresh_token(payload)
-
-
-```
-In the above illustration,
-we decorated AuthController with `@AuthenticationRequired('JWTAuthentication')`
-to ensure we have authenticated user before executing any route function and, 
-we passed in `JWTAuthentication` as a parameter,
-which will be used in openapi doc to define the controller routes security scheme.
-
-It is importance to note that when using `AuthenticationHandler` approach,
-that you have
-to always use `AuthenticationRequired` decorator on route functions or controller
-that needs protected from anonymous users.
-
-But if you have a single form of authentication,
-you can register `AuthenticatedRequiredGuard` from `eellar.auth.guard` module globally
-just like we did in [applying guard globally](#apply-authguard-globally)
-
-```python title='auth/module.py' linenums='1'
-from datetime import timedelta
-from ellar.auth.guard import AuthenticatedRequiredGuard
-from ellar.common import GlobalGuard, Module
-from ellar.core import ModuleBase, LazyModuleImport as lazyLoad
-from ellar.di import ProviderConfig
-from ellar_jwt import JWTModule
-
-from .controllers import AuthController
-from .services import AuthService
-
-
-@Module(
-    modules=[
-        lazyLoad('project_name.users.module:UserModule'),
-        JWTModule.setup(
-            signing_secret_key="my_poor_secret_key_lol", lifetime=timedelta(minutes=5)
-        ),
-    ],
-    controllers=[AuthController],
-    providers=[AuthService, ProviderConfig(GlobalGuard, use_value=AuthenticatedRequiredGuard('JWTAuthentication', []))],
-)
-class AuthModule(ModuleBase):
-    """
-    Auth Module
-    """
-```
-
-Still having the server running, we can test as before
-
-```shell
-$ # GET /auth/profile
-$ curl http://localhost:8000/auth/profile
-{"detail":"Forbidden"} # status_code=403
-
-$ # POST /auth/login
-$ curl -X POST http://localhost:8000/auth/login -d '{"username": "john", "password": "password"}' -H "Content-Type: application/json"
-{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2OTg3OTE0OTE..."}
-
-$ # GET /profile using access_token returned from previous step as bearer code
-$ curl http://localhost:8000/auth/profile -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2Vybm..."
-{"exp":1698793558,"iat":1698793258,"jti":"e96e94c5c3ef4fbbbd7c2468eb64534b","sub":1,"user_id":1,"username":"john", "id":null,"auth_type":"bearer"}
-
-```
-Source Code to this example is [here](https://github.com/python-ellar/ellar/tree/main/examples/04-auth-with-handlers)

--- a/ellar/app/__init__.py
+++ b/ellar/app/__init__.py
@@ -1,7 +1,19 @@
+from .context import (
+    enable_versioning,
+    use_authentication_schemes,
+    use_exception_handler,
+    use_global_guards,
+    use_global_interceptors,
+)
 from .factory import AppFactory
 from .main import App
 
 __all__ = [
     "App",
     "AppFactory",
+    "use_exception_handler",
+    "use_global_guards",
+    "use_global_interceptors",
+    "use_authentication_schemes",
+    "enable_versioning",
 ]

--- a/ellar/app/context.py
+++ b/ellar/app/context.py
@@ -1,0 +1,120 @@
+import typing as t
+
+from ellar.auth.handlers import AuthenticationHandlerType
+from ellar.common import (
+    EllarInterceptor,
+    GuardCanActivate,
+    IExceptionHandler,
+    IIdentitySchemes,
+)
+from ellar.core import VersioningSchemes, current_config, current_injector
+from ellar.di import is_decorated_with_injectable
+from ellar.di.injector.tree_manager import TreeData
+from ellar.events import ensure_build_context
+
+
+@ensure_build_context(app_ready=True)
+def ensure_available_in_providers(*items: t.Any) -> None:
+    """
+    Ensures that Providers at least belows to a particular module
+    :param items:
+    :return:
+    """
+    app_module = current_injector.tree_manager.get_app_module()
+
+    def _predicate(item_: t.Type) -> t.Callable:
+        def _(data: TreeData) -> bool:
+            return item_ in data.exports or item_ in data.providers
+
+        return _
+
+    for item in items:
+        if isinstance(item, type) and is_decorated_with_injectable(item):
+            module = next(
+                app_module.tree_manager.find_module(predicate=_predicate(item))
+            )
+            if not module:
+                # if no module was found, we add item to ApplicationModule and export it also
+                app_module.tree_manager.get_app_module().add_provider(
+                    provider=item, export=True
+                )
+
+
+@ensure_build_context(app_ready=True)
+def use_authentication_schemes(*authentication: AuthenticationHandlerType) -> None:
+    """
+    Registered Authentication Handlers to the application
+    :param authentication:
+    :return:
+    """
+    __identity_scheme = current_injector.get(IIdentitySchemes)
+    for auth in authentication:
+        __identity_scheme.add_authentication(auth)
+        ensure_available_in_providers(auth)
+
+
+@ensure_build_context()
+def use_exception_handler(
+    *exception_handlers: IExceptionHandler,
+) -> None:
+    """
+    Adds Application Exception Handlers
+    :param exception_handlers: IExceptionHandler
+    :return:
+    """
+    for exception_handler in exception_handlers:
+        if exception_handler not in current_config.EXCEPTION_HANDLERS:
+            current_config.EXCEPTION_HANDLERS = current_config.EXCEPTION_HANDLERS + [
+                exception_handler
+            ]
+            ensure_available_in_providers(exception_handler)
+
+
+@ensure_build_context()
+def enable_versioning(
+    schema: VersioningSchemes,
+    version_parameter: str = "version",
+    default_version: t.Optional[str] = None,
+    **init_kwargs: t.Any,
+) -> None:
+    """
+    Enables an Application Versioning scheme
+    :param schema: VersioningSchemes
+    :param version_parameter: versioning parameter lookup key. Default: 'version'
+    :param default_version: versioning default value. Default: None
+    :param init_kwargs: Other schema initialization keyword args.
+    :return:
+    """
+    current_config.VERSIONING_SCHEME = schema.value(
+        version_parameter=version_parameter,
+        default_version=default_version,
+        **init_kwargs,
+    )
+
+
+@ensure_build_context(app_ready=True)
+def use_global_guards(
+    *guards: t.Union[GuardCanActivate, t.Type[GuardCanActivate]],
+) -> None:
+    """
+    Registers Application Global Guards that affects all routes registered in ApplicationRouter
+    :param guards:
+    :return: None
+    """
+    current_config.GLOBAL_GUARDS = list(current_config.GLOBAL_GUARDS) + list(guards)
+    ensure_available_in_providers(*guards)
+
+
+@ensure_build_context(app_ready=True)
+def use_global_interceptors(
+    *interceptors: t.Union[EllarInterceptor, t.Type[EllarInterceptor]],
+) -> None:
+    """
+    Registers Application Global Interceptor that affects all routes registered in ApplicationRouter
+    :param interceptors:
+    :return: None
+    """
+    current_config.GLOBAL_INTERCEPTORS = list(
+        current_config.GLOBAL_INTERCEPTORS
+    ) + list(interceptors)
+    ensure_available_in_providers(*interceptors)

--- a/ellar/app/factory.py
+++ b/ellar/app/factory.py
@@ -21,7 +21,7 @@ from ellar.di import EllarInjector, ProviderConfig
 from ellar.di.injector.tree_manager import ModuleTreeManager
 from ellar.reflect import reflect
 from ellar.threading.sync_worker import execute_async_context_manager, execute_coroutine
-from ellar.utils import get_name, get_unique_type
+from ellar.utils import get_unique_type
 from starlette.routing import Host, Mount
 
 from ..events.build import build_with_context_event
@@ -108,6 +108,7 @@ class AppFactory:
             return dict(config_module)
 
         config = Config(app_configured=True, **_get_config_kwargs())
+        config.GLOBAL_GUARDS += list(global_guards or [])
 
         # injector = EllarInjector(auto_bind=config.INJECTOR_AUTO_BIND, parent=injector)
         # injector.container.register_instance(config, concrete_type=Config)
@@ -137,11 +138,10 @@ class AppFactory:
                 config=config,
                 injector=app_module_ref.container.injector,
                 lifespan=config.DEFAULT_LIFESPAN_HANDLER,
-                global_guards=global_guards,
             )
             # tag application instance by ApplicationModule name
             core_module_ref.add_provider(
-                ProviderConfig(App, use_value=app, tag=get_name(module), export=True)
+                ProviderConfig(App, use_value=app, tag="App", export=True)
             )
             app_module_ref.build_dependencies()
 

--- a/ellar/common/__init__.py
+++ b/ellar/common/__init__.py
@@ -56,7 +56,6 @@ from .models import (
     ControllerBase,
     ControllerType,
     EllarInterceptor,
-    GlobalGuard,
     GuardCanActivate,
     Identity,
 )
@@ -106,7 +105,6 @@ __all__ = [
     "serialize_object",
     "ControllerType",
     "GuardCanActivate",
-    "GlobalGuard",
     "Serializer",
     "WebSocketException",
     "APIException",

--- a/ellar/common/models/__init__.py
+++ b/ellar/common/models/__init__.py
@@ -1,5 +1,5 @@
 from .controller import ControllerBase, ControllerType
-from .guard import GlobalGuard, GuardCanActivate
+from .guard import GuardCanActivate
 from .identity import AnonymousIdentity, Identity
 from .interceptor import EllarInterceptor
 
@@ -10,5 +10,4 @@ __all__ = [
     "EllarInterceptor",
     "Identity",
     "GuardCanActivate",
-    "GlobalGuard",
 ]

--- a/ellar/common/models/guard.py
+++ b/ellar/common/models/guard.py
@@ -20,6 +20,3 @@ class GuardCanActivate(ABC, metaclass=ABCMeta):
 
     def raise_exception(self) -> None:
         raise self.exception_class(status_code=self.status_code, detail=self.detail)
-
-
-GlobalGuard = t.NewType("GlobalGuard", GuardCanActivate)

--- a/ellar/core/conf/mixins.py
+++ b/ellar/core/conf/mixins.py
@@ -1,5 +1,6 @@
 import typing as t
 
+from ellar.common import EllarInterceptor, GuardCanActivate
 from ellar.common.constants import LOG_LEVELS as log_levels
 from ellar.common.interfaces import IAPIVersioning, IEllarMiddleware, IExceptionHandler
 from ellar.common.templating import JinjaLoaderType
@@ -102,5 +103,9 @@ class ConfigDefaultTypesMixin:
     # TrustHostMiddleware setup
     ALLOWED_HOSTS: t.List[str]
     REDIRECT_HOST: bool
-
+    # Cache Module setup
     CACHES: t.Dict[str, t.Any]
+    # Application Global Guards
+    GLOBAL_GUARDS: t.List[t.Union[GuardCanActivate, t.Type[GuardCanActivate]]]
+    # Application Global Interceptors
+    GLOBAL_INTERCEPTORS: t.List[t.Union[EllarInterceptor, t.Type[EllarInterceptor]]]

--- a/ellar/core/module.py
+++ b/ellar/core/module.py
@@ -3,8 +3,6 @@ import typing as t
 from ellar.auth import AppIdentitySchemes, IdentityAuthenticationService
 from ellar.auth.session import SessionServiceNullStrategy, SessionStrategy
 from ellar.common import (
-    GlobalGuard,
-    GuardCanActivate,
     IApplicationShutdown,
     IApplicationStartup,
     IExceptionMiddlewareService,
@@ -33,7 +31,7 @@ from ellar.core.execution_context.factory import (
 from ellar.core.guards import GuardConsumer
 from ellar.core.interceptors import EllarInterceptorConsumer
 from ellar.core.services import Reflector, reflector
-from ellar.di import EllarInjector, ProviderConfig, injectable, request_scope
+from ellar.di import EllarInjector, ProviderConfig, request_scope
 from ellar.di.injector.tree_manager import ModuleTreeManager
 from ellar.events import app_context_started, app_context_teardown
 
@@ -45,14 +43,6 @@ def _raise_unavailable_exception() -> None:
     raise Exception("Service is only available during request")
 
 
-@injectable
-class GlobalCanActivatePlaceHolder(GuardCanActivate):
-    placeholder: bool = True
-
-    async def can_activate(self, context: IExecutionContext) -> bool:
-        return True
-
-
 def get_core_module(app_module: t.Union[t.Type, t.Any], config: Config) -> t.Type:
     @Module(
         modules=[app_module],
@@ -60,11 +50,6 @@ def get_core_module(app_module: t.Union[t.Type, t.Any], config: Config) -> t.Typ
             ProviderConfig(
                 Config,
                 use_value=config,
-                export=True,
-            ),
-            ProviderConfig(
-                GlobalGuard,
-                use_class=GlobalCanActivatePlaceHolder,
                 export=True,
             ),
             ProviderConfig(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,9 @@ nav:
       - Background Tasks: techniques/background-task.md
 
   - Security:
-      - Authentication: security/authentication.md
+      - Authentication:
+          - Guard Strategy: security/authentication/guard-strategy.md
+          - Authentication Scheme Strategy: security/authentication/auth-handler-strategy.md
       - Authorization: security/authorization.md
       - Encryption and Hashing: security/encryption_and_hashing.md
       - CSRF and CORS: security/csrf.md

--- a/samples/02-socketio-app/socketio_app/server.py
+++ b/samples/02-socketio-app/socketio_app/server.py
@@ -12,7 +12,6 @@ application = AppFactory.create_from_app_module(
     config_module=os.environ.get(
         ELLAR_CONFIG_MODULE, "socketio_app.config:DevelopmentConfig"
     ),
-    global_guards=[],
 )
 
 # uncomment this section if you want API documentation

--- a/samples/03-auth-with-guards/auth_project/auth/module.py
+++ b/samples/03-auth-with-guards/auth_project/auth/module.py
@@ -18,15 +18,18 @@ class MyModule(ModuleBase):
 
 """
 
-from ellar.common import GlobalGuard, Module
+from ellar.app import use_global_guards
+from ellar.common import Module
 from ellar.core import ForwardRefModule, ModuleBase
 from ellar.core import LazyModuleImport as lazyLoad
-from ellar.di import ProviderConfig
 from ellar_jwt import JWTModule
 
 from .controllers import AuthController
 from .guards import AuthGuard
 from .services import AuthService
+
+## Sets AuthGuard as a GLOBAL GUARD in application config.
+use_global_guards(AuthGuard)
 
 
 @Module(
@@ -37,7 +40,6 @@ from .services import AuthService
     controllers=[AuthController],
     providers=[
         AuthService,
-        ProviderConfig(GlobalGuard, use_class=AuthGuard, core=True),
     ],
 )
 class AuthModule(ModuleBase):

--- a/samples/04-auth-with-handlers/auth_project_with_handler/auth/module.py
+++ b/samples/04-auth-with-handlers/auth_project_with_handler/auth/module.py
@@ -20,13 +20,18 @@ class MyModule(ModuleBase):
 
 from datetime import timedelta
 
+from ellar.app import use_authentication_schemes
 from ellar.common import Module
 from ellar.core import LazyModuleImport as lazyLoad
 from ellar.core import ModuleBase
 from ellar_jwt import JWTModule
 
+from .auth_scheme import JWTAuthentication
 from .controllers import AuthController
 from .services import AuthService
+
+# Register JWTAuthentication as an authentication scheme
+use_authentication_schemes(JWTAuthentication)
 
 
 @Module(

--- a/samples/04-auth-with-handlers/auth_project_with_handler/root_module.py
+++ b/samples/04-auth-with-handlers/auth_project_with_handler/root_module.py
@@ -1,10 +1,4 @@
-from ellar.common import (
-    IExecutionContext,
-    JSONResponse,
-    Module,
-    Response,
-    exception_handler,
-)
+from ellar.common import Module
 from ellar.core import LazyModuleImport as lazyLoad
 from ellar.core import ModuleBase
 from ellar.samples.modules import HomeModule
@@ -14,6 +8,4 @@ from ellar.samples.modules import HomeModule
     modules=[HomeModule, lazyLoad("auth_project_with_handler.auth.module:AuthModule")]
 )
 class ApplicationModule(ModuleBase):
-    @exception_handler(404)
-    def exception_404_handler(self, ctx: IExecutionContext, exc: Exception) -> Response:
-        return JSONResponse({"detail": "Resource not found."})
+    pass

--- a/samples/04-auth-with-handlers/auth_project_with_handler/server.py
+++ b/samples/04-auth-with-handlers/auth_project_with_handler/server.py
@@ -9,16 +9,12 @@ from ellar.openapi import (
     SwaggerUI,
 )
 
-from .auth.auth_scheme import JWTAuthentication
-
 application = AppFactory.create_from_app_module(
     lazyLoad("auth_project_with_handler.root_module:ApplicationModule"),
     config_module=os.environ.get(
         ELLAR_CONFIG_MODULE, "auth_project_with_handler.config:DevelopmentConfig"
     ),
 )
-# Register JWTAuthentication as an authentication scheme
-application.add_authentication_schemes(JWTAuthentication)
 
 # uncomment this section if you want API documentation
 

--- a/samples/05-ellar-with-sqlalchemy/db_learning/server.py
+++ b/samples/05-ellar-with-sqlalchemy/db_learning/server.py
@@ -12,7 +12,6 @@ def bootstrap() -> App:
         config_module=os.environ.get(
             ELLAR_CONFIG_MODULE, "db_learning.config:DevelopmentConfig"
         ),
-        global_guards=[],
     )
 
     # uncomment this section if you want API documentation

--- a/tests/test_application/test_application_factory.py
+++ b/tests/test_application/test_application_factory.py
@@ -121,7 +121,7 @@ def test_config_overrider_core_service_registration():
 
 
 async def test_ensure_build_works(anyio_backend):
-    @ensure_build_context
+    @ensure_build_context()
     def set_xxx(key, value):
         current_config[key] = value
 
@@ -129,7 +129,7 @@ async def test_ensure_build_works(anyio_backend):
     set_xxx("DES_34", 34)
 
     app = AppFactory.create_app()
-    async with injector_context(app.injector):
+    async with app.with_injector_context():
         set_xxx("DES_345", 23432)
 
     assert app.config.DES == 12

--- a/tests/test_auth/test_guards/test_auth_guards.py
+++ b/tests/test_auth/test_guards/test_auth_guards.py
@@ -10,7 +10,6 @@ from ellar.auth.guards import (
 )
 from ellar.common import (
     APIException,
-    GlobalGuard,
     Inject,
     ModuleRouter,
     UseGuards,
@@ -18,7 +17,7 @@ from ellar.common import (
     serialize_object,
 )
 from ellar.core import Reflector, Request
-from ellar.di import ProviderConfig, injectable
+from ellar.di import injectable
 from ellar.openapi import OpenAPIDocumentBuilder
 from ellar.testing import TestClient
 from starlette.status import HTTP_401_UNAUTHORIZED
@@ -292,8 +291,7 @@ def test_global_guard_case_2_works():
         return {"authentication": request.user}
 
     _app = AppFactory.create_app(
-        routers=[_auth_demo_endpoint],
-        providers=[ProviderConfig(GlobalGuard, use_class=DigestAuth, core=True)],
+        routers=[_auth_demo_endpoint], config_module={"GLOBAL_GUARDS": [DigestAuth]}
     )
 
     _client = TestClient(_app)
@@ -332,7 +330,7 @@ def test_if_an_auth_guard_return_converts_to_identity(
         return {"authentication": request.user}
 
     _app = AppFactory.create_app(
-        providers=[ProviderConfig(GlobalGuard, use_class=DigestAuth, core=True)],
+        config_module={"GLOBAL_GUARDS": [DigestAuth]},
         routers=[_auth_demo_endpoint],
     )
     _client = TestClient(_app)


### PR DESCRIPTION
## Whats changed
- Dropped `GlobalGuard` as Provider config 
- Moved all `GLOBAL_GUARDS` and `GLOBAL_INTERCEPTORS` to application config
- Exposed Application methods as functions: `use_exception_handler`,`use_global_guards`,`use_global_interceptors`,`use_authentication_schemes`
